### PR TITLE
Add a multiple-line TSV file parser.

### DIFF
--- a/frontend/Pages/OpenAI/Index.razor
+++ b/frontend/Pages/OpenAI/Index.razor
@@ -230,7 +230,6 @@
         finally
         {
             loading = false;
-            System.Diagnostics.Debug.WriteLine(tsvCommitMessages);
         }
     }
 

--- a/frontend/Pages/OpenAI/Index.razor
+++ b/frontend/Pages/OpenAI/Index.razor
@@ -109,7 +109,7 @@
             <tbody>
             @if (commitResponses != null)
             {
-                @for (int i = 0; i < commitResponses.Count; i++)
+                @for (var i = 0; i < commitResponses.Count; i++)
                 {
                     <tr>
                         <td>@i</td>
@@ -187,15 +187,39 @@
             fileName = e.File.Name;
             var loopable = System.Text.Encoding.UTF8.GetString(ms.ToArray());
 
-            var items = loopable.Split(Environment.NewLine);
-            for (var i = 0; i < items.Length; i++)
+            var lines = loopable.Split(Environment.NewLine);
+
+            var content = "";
+            var isMultiline = false;
+
+            for (var i = 0; i < lines.Length; i++)
             {
                 if (i == 0) continue;
-                var columnIndex = 0;
-                var message = items[i].Split('\t');
-                if (columnIndex < message.Length)
+
+                var line = lines[i];
+
+                if (!isMultiline)
                 {
-                    tsvCommitMessages.Add(message[columnIndex]);
+                    isMultiline = line.StartsWith('"');
+                    line = line.Remove(0, 1);
+                }
+
+                content += $"{line.Split('\t')[0]} ";
+
+                if (isMultiline)
+                {
+                    var isEndMultiline = line.EndsWith("\"\r");
+                    if (!isEndMultiline && i != lines.Length) continue;
+
+                    content = content.Remove(content.Length - 3);
+                    tsvCommitMessages.Add(content);
+                    isMultiline = false;
+                    content = "";
+                }
+                else
+                {
+                    tsvCommitMessages.Add(content);
+                    content = "";
                 }
             }
         }
@@ -206,6 +230,7 @@
         finally
         {
             loading = false;
+            System.Diagnostics.Debug.WriteLine(tsvCommitMessages);
         }
     }
 
@@ -216,11 +241,11 @@
 
     private async IAsyncEnumerable<CommitResponse> getSummarizationsAsync()
     {
-        for (var i = 0; i < tsvCommitMessages.Count; i++)
+        foreach (var commitMessage in tsvCommitMessages)
         {
             if (shouldStopExtracting) break;
             var cs = new CommitResponse();
-            cs.commit = tsvCommitMessages[i];
+            cs.commit = commitMessage;
             try
             {
                 var dto = new OpenAIExtractDTO();

--- a/frontend/Pages/OpenAI/Index.razor
+++ b/frontend/Pages/OpenAI/Index.razor
@@ -211,7 +211,11 @@
                     var isEndMultiline = line.EndsWith("\"\r");
                     if (!isEndMultiline && i != lines.Length) continue;
 
-                    content = content.Remove(content.Length - 3);
+                    if (isEndMultiline)
+                    {
+                        content = content.Remove(content.Length - 2);
+                    }
+                    
                     tsvCommitMessages.Add(content);
                     isMultiline = false;
                     content = "";


### PR DESCRIPTION
Previously, we encountered an issue where the parsing of files was incorrect.
This was due to the files being split by line, but commit messages were multi-line.
Which resulted in messages being split at incorrect places, instead of concatenating them together.

Now, the parser has been updated to support multiple lines. This was resolved with the help of quotes.
When a file has multi line, the text is between quotes. When it's single-line, it doesn't have quotes.
The parser takes advantage of this, and resolves the previous issue.